### PR TITLE
Improve Eww UI with multi-screen support, Esc key, and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ cargo build --release
 
 # Copy the binary to your path
 sudo cp target/release/niflveil /usr/local/bin/
+
+# If using EWW
+# Create the niflveil widget folder in /etc/xdg/eww/widgets
+mkdir /etc/xdg/eww/widgets/niflveil
+
+# Copy eww contents to widgets folder
+sudo cp eww/* /etc/xdg/eww/widgets/niflveil/ 
 ```
 
 ### 2. Add the bindings you want to your Hyprland config:
@@ -58,6 +65,9 @@ bind = SUPER, U, exec, /usr/local/bin/niflveil restore-last
 
 # Restore all minimized windows 
 bind = $mainMod SHIFT, U, exec, /usr/local/bin/niflveil restore-all
+
+# Close EWW interface with ESC key
+bindn = , escape, exec, eww --config /etc/xdg/eww/widgets/niflveil/ close niflveil
 
 # PS: If you are using the EWW window, add the following to the end
 # of the bindings: "&& eww reload --config /etc/xdg/eww/widgets/niflveil"

--- a/niflveil/.gitignore
+++ b/niflveil/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/niflveil/Cargo.toml
+++ b/niflveil/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Maui_The_Magnificent"]
 description = "A window minimizer for Hyprland"
 
 [dependencies]
+serde_json = "1.0.145"
 
 [profile.release]
 opt-level = 3

--- a/niflveil/eww/eww.yuck
+++ b/niflveil/eww/eww.yuck
@@ -25,7 +25,7 @@
          :space-evenly false
       (label :text "Minimized Windows" :class "title")
       (button :class "close-btn"
-              :onclick "eww close niflveil"
+              :onclick "eww --config /etc/xdg/eww/widgets/niflveil/ close niflveil"
         "✕"))
 (button :class "restore-all-btn"
         :onclick "niflveil restore-all"

--- a/niflveil/src/main.rs
+++ b/niflveil/src/main.rs
@@ -39,6 +39,39 @@ struct MinimizedWindow {
     icon: String,
 }
 
+fn get_focused_monitor() -> io::Result<String> {
+    let output = Command::new("hyprctl")
+        .args(["monitors", "-j"])
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            let monitors_json = String::from_utf8_lossy(&output.stdout);
+
+            // Try to parse the JSON
+            if let Ok(monitors) = serde_json::from_str::<serde_json::Value>(&monitors_json) {
+                if let Some(monitor) = monitors
+                    .as_array()
+                    .and_then(|arr| arr.iter().find(|m| m["focused"].as_bool().unwrap_or(false)))
+                {
+                    if let Some(id) = monitor["id"].as_i64() {
+                        return Ok(id.to_string());
+                    }
+                }
+            }
+
+            // Parsing failed or no focused monitor found -> fallback
+            eprintln!("⚠️  Could not determine focused monitor, falling back to 0");
+            Ok("0".to_string())
+        }
+        _ => {
+            // hyprctl itself failed -> fallback
+            eprintln!("⚠️  hyprctl failed, falling back to monitor 0");
+            Ok("0".to_string())
+        }
+    }
+}
+
 fn get_app_icon(class_name: &str) -> String {
     ICONS
         .iter()
@@ -218,11 +251,14 @@ fn show_restore_menu() -> io::Result<()> {
         return Ok(());
     }
 
+    let monitor = get_focused_monitor()?;
     let eww_result = Command::new("eww")
         .args([
             "--config",
             "/etc/xdg/eww/widgets/niflveil/",
             "open",
+            "--screen",
+            &monitor,
             "niflveil",
         ])
         .output()?;
@@ -236,14 +272,14 @@ fn show_restore_menu() -> io::Result<()> {
         println!("Eww window opened successfully");
     }
 
-    Command::new("eww")
-        .args([
-            "--config",
-            "/etc/xdg/eww/widgets/niflveil/",
-            "close",
-            "niflveil",
-        ])
-        .output()?;
+    // Command::new("eww")
+    //     .args([
+    //         "--config",
+    //         "/etc/xdg/eww/widgets/niflveil/",
+    //         "close",
+    //         "niflveil",
+    //     ])
+    //     .output()?;
 
     Ok(())
 }


### PR DESCRIPTION
## Setup
- Hyprland v0.51.0
- eww v0.5.0
- Waybar v0.14.0

## Features added

Multi-screen support:
The restore menu now opens on the currently focused screen using `--screen` instead of being hardcoded to monitor `0`.

Persistent window:
Removed the logic that immediately closed the menu after opening, so the user can actually interact with it.

Esc key support:
Added handling to close the restore menu with the Esc key via Hyprland, making it more intuitive.

## Bug fixes

Fixed minor issues in the restore logic and UI responsiveness.

Improved fallback behavior to avoid crashes if monitor detection fails while using hyprctl.

## Testing

Verified on a dual-monitor Hyprland setup.

Confirmed behavior on single-monitor setups remains unchanged.