### PR TITLE
Update dispatch commands for new lua syntax

### DIFF
--- a/niflveil/src/main.rs
+++ b/niflveil/src/main.rs
@@ -160,8 +160,10 @@ fn restore_specific_window(window_id: &str) -> io::Result<()> {
     let move_from_special = Command::new("hyprctl")
         .args([
             "dispatch",
-            "movetoworkspace",
-            &format!("{},address:{}", current_ws, window_id),
+            &format!(
+                "hl.dsp.window.move({{ workspace = '{}', window = 'address:{}', follow = true }})",
+                current_ws, window_id
+            ),
         ])
         .output()?;
 
@@ -171,7 +173,10 @@ fn restore_specific_window(window_id: &str) -> io::Result<()> {
     );
 
     let focus_cmd = Command::new("hyprctl")
-        .args(["dispatch", "focuswindow", &format!("address:{}", window_id)])
+        .args([
+            "dispatch",
+            &format!("hl.dsp.focus({{ window = 'address:{}' }})", window_id),
+        ])
         .output()?;
 
     println!("Focus command result: {:?}", focus_cmd);
@@ -311,8 +316,7 @@ fn minimize_window() -> Result<(), io::Error> {
     let output = Command::new("hyprctl")
         .args([
             "dispatch",
-            "movetoworkspacesilent",
-            &format!("special:minimum,address:{}", window_addr),
+            "hl.dsp.window.move({ workspace = 'special:minimum', follow = false })",
         ])
         .output()?;
 


### PR DESCRIPTION
fixes #10.

This is my attempt at fixing support for hyprland 0.55. I cannot know for certain if this is the most optimal way to do this, but this was the best I could figure out based on hyprland's wiki, and it seems to work fine on my PC at least.